### PR TITLE
Add Gaudi hpu accelerator option to BaseCAM

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ two smoothing methods are supported:
 Usage: `python cam.py --image-path <path_to_image> --method <method> --output-dir <output_dir_path> `
 
 
-To use with a specific device, like cpu, cuda, cuda:0 or mps:
+To use with a specific device, like cpu, cuda, cuda:0, mps or hpu:
 `python cam.py --image-path <path_to_image> --device cuda  --output-dir <output_dir_path> `
 
 ----------

--- a/cam.py
+++ b/cam.py
@@ -77,6 +77,9 @@ if __name__ == '__main__':
         'kpcacam': KPCA_CAM
     }
 
+    if args.device=='hpu':
+        import habana_frameworks.torch.core as htcore
+
     model = models.resnet50(pretrained=True).to(torch.device(args.device)).eval()
 
     # Choose the target layer you want to compute the visualization for.

--- a/pytorch_grad_cam/base_cam.py
+++ b/pytorch_grad_cam/base_cam.py
@@ -26,7 +26,11 @@ class BaseCAM:
         # Use the same device as the model.
         self.device = next(self.model.parameters()).device
         if 'hpu' in str(self.device):
-            import habana_frameworks.torch.core as htcore
+            try:
+                import habana_frameworks.torch.core as htcore
+            except ImportError as error:
+                error.msg = f"Could not import habana_frameworks.torch.core. {error.msg}."
+                raise error
             self.__htcore = htcore
         self.reshape_transform = reshape_transform
         self.compute_input_gradient = compute_input_gradient

--- a/pytorch_grad_cam/base_cam.py
+++ b/pytorch_grad_cam/base_cam.py
@@ -25,6 +25,9 @@ class BaseCAM:
 
         # Use the same device as the model.
         self.device = next(self.model.parameters()).device
+        if 'hpu' in str(self.device):
+            import habana_frameworks.torch.core as htcore
+            self.__htcore = htcore
         self.reshape_transform = reshape_transform
         self.compute_input_gradient = compute_input_gradient
         self.uses_gradients = uses_gradients
@@ -97,6 +100,8 @@ class BaseCAM:
             self.model.zero_grad()
             loss = sum([target(output) for target, output in zip(targets, outputs)])
             loss.backward(retain_graph=True)
+            if 'hpu' in str(self.device):
+                self.__htcore.mark_step()
 
         # In most of the saliency attribution papers, the saliency is
         # computed with a single target layer.


### PR DESCRIPTION
Hello!

This PR adds the option for users to use `BaseCAM` with Intel's Gaudi platform. The `htcore` import and `mark_step()` call are all  that is needed in `base_cam.py` and I've added the `'hpu'` arg in `cam.py`. 

It should be noted that Gaudi needs a few (depending on model and input feature size) warmup executions before seeing the best computation time and is best for running GradCAM on large batches.

## Steps to use `cam.py` on a Gaudi platform
### Option 1. **If you do not have access to a Gaudi locally** 
a. Use the free [Tiber Cloud](https://developer.habana.ai/intel-ai-cloud/) 
b. In a terminal tab on the Jupyter lab interface, clone this branch
```
git clone -b daniel/enable_gaudi https://github.com/daniel-de-leon-user293/pytorch-grad-cam.git
```
c. Install dependencies
```
cd pytorch-grad-cam
pip install -e .
```
d. Run `cam.py`
```
python3 cam.py --device hpu
```

### Option 2. **If you do have access to a Gaudi locally** 
a. Clone this branch on your Gaudi machine
```
git clone -b daniel/enable_gaudi https://github.com/daniel-de-leon-user293/pytorch-grad-cam.git
```
b. Start a Gaudi container that mounts this branch
```
docker run -d --rm -it --name gradcam-hpu -v pytorch-grad-cam:/workdir --runtime=habana \ 
-e http_proxy=$http_proxy -e https_proxy=$https_proxy \ 
-e HABANA_VISIBLE_DEVICES=all -e OMPI_MCA_btl_vader_single_copy_mechanism=none \ 
--cap-add=sys_nice --net=host --ipc=host \ 
vault.habana.ai/gaudi-docker/1.18.0/ubuntu22.04/habanalabs/pytorch-installer-2.2.2:latest
```
c. Exec into the interactive container
```
docker exec -it gradcam-hpu bash
```
d. Install dependencies
```
cd pytorch-grad-cam
pip install -e .
```
e. Run `cam.py`
```
python3 cam.py --device hpu
```

Thank you and look forward to hearing your feedback!